### PR TITLE
Fix logger time

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -20,11 +20,11 @@ export function logger(winstonInstance) {
 
     return async(ctx: Koa.Context, next: () => Promise<any>) => {
 
-        const start = new Date().getMilliseconds();
+        const start = new Date().getTime();
 
         await next();
 
-        const ms = new Date().getMilliseconds() - start;
+        const ms = new Date().getTime() - start;
 
         let logLevel: string;
         if (ctx.status >= 500) {


### PR DESCRIPTION
Using getMilliseconds() is inappropriate because if the request takes over 999ms the result will be inaccurate.

Example:
Start: 12:00:00:576 (576 is taken)
End: 12:00:05:126 (126 is taken)

Result in current implementation: -450ms
Result in fix: 4550ms